### PR TITLE
Update ProblemDetails references to use ASP.NET Core

### DIFF
--- a/RestfulHelpers/Common/HttpError.cs
+++ b/RestfulHelpers/Common/HttpError.cs
@@ -24,7 +24,7 @@ public class HttpError : Error
     {
         get
         {
-            if (Detail is ProblemDetails problemDetails)
+            if (Detail is Microsoft.AspNetCore.Mvc.ProblemDetails problemDetails)
             {
                 return (HttpStatusCode)(problemDetails.Status ?? default);
             }
@@ -44,7 +44,7 @@ public class HttpError : Error
         set
         {
             Code = value.ToString().ToSnakeCase().ToUpper();
-            Detail = new ProblemDetails() { Status = (int)value };
+            Detail = new Microsoft.AspNetCore.Mvc.ProblemDetails() { Status = (int)value };
             if (string.IsNullOrEmpty(Message))
             {
                 Message = "StatusCode: " + value;
@@ -52,7 +52,7 @@ public class HttpError : Error
         }
     }
 
-    internal void SetStatusCode(HttpStatusCode statusCode, ProblemDetails problemDetails)
+    internal void SetStatusCode(HttpStatusCode statusCode, Microsoft.AspNetCore.Mvc.ProblemDetails? problemDetails)
     {
         StatusCode = statusCode;
         Detail = problemDetails;

--- a/RestfulHelpers/Common/HttpResultResponse.cs
+++ b/RestfulHelpers/Common/HttpResultResponse.cs
@@ -67,7 +67,7 @@ internal class HttpResultResponse : IHttpResultResponse
             httpContext.Response.Headers.Append(header.Key, header.Value);
         }
 
-        return httpContext.Response.WriteAsJsonAsync(HttpResult, RestfulHelpersJsonSerializerContext.HttpResult);
+        return httpContext.Response.WriteAsJsonAsync(HttpResult.SafeClone(), RestfulHelpersJsonSerializerContext.HttpResult);
     }
 
     public Task ExecuteResultAsync(ActionContext context)
@@ -145,7 +145,7 @@ internal class HttpResultResponse<T> : IHttpResultResponse<T>
         {
             using var jsonWriter = new Utf8JsonWriter(httpContext.Response.BodyWriter);
 
-            var jsonNode = JsonSerializer.SerializeToNode(HttpResult, RestfulHelpersJsonSerializerContext.IHttpResult)!;
+            var jsonNode = JsonSerializer.SerializeToNode(HttpResult.SafeClone(), RestfulHelpersJsonSerializerContext.IHttpResult)!;
 
             string valuePropName = JsonTypeInfo.Options.PropertyNamingPolicy?.ConvertName("Value") ?? "value";
 

--- a/RestfulHelpers/Common/RestfulHelpersJsonSerializerContext.cs
+++ b/RestfulHelpers/Common/RestfulHelpersJsonSerializerContext.cs
@@ -12,7 +12,7 @@ namespace RestfulHelpers.Common;
 
 #if NET7_0_OR_GREATER
 /// <inheritdoc/>
-public class ProblemDetails : global::Microsoft.AspNetCore.Mvc.ProblemDetails { }
+internal class PatchForProblemDetails : global::Microsoft.AspNetCore.Mvc.ProblemDetails { }
 
 [JsonSerializable(typeof(Result))]
 [JsonSerializable(typeof(Error))]
@@ -21,7 +21,7 @@ public class ProblemDetails : global::Microsoft.AspNetCore.Mvc.ProblemDetails { 
 [JsonSerializable(typeof(List<Error>))]
 [JsonSerializable(typeof(IResult))]
 [JsonSerializable(typeof(IHttpResult))]
-[JsonSerializable(typeof(ProblemDetails))]
+[JsonSerializable(typeof(PatchForProblemDetails))]
 internal partial class RestfulHelpersJsonSerializerContext : JsonSerializerContext
 {
     internal static RestfulHelpersJsonSerializerContext WebDefault { get; } = new(new JsonSerializerOptions


### PR DESCRIPTION
Update ProblemDetails references to use ASP.NET Core

Refactor `HttpError` to utilize `Microsoft.AspNetCore.Mvc.ProblemDetails`.
Update `SetStatusCode` and `WithStatusCode` methods accordingly.
Introduce `SafeClone` method for cloning `HttpResult` with proper error handling.
Modify `HttpResultResponse` classes to use cloned results.
Add `PatchForProblemDetails` for serialization context.