### PR TITLE
Add SetStatusCode method to HttpError class

### DIFF
--- a/RestfulHelpers/Common/HttpError.cs
+++ b/RestfulHelpers/Common/HttpError.cs
@@ -52,6 +52,29 @@ public class HttpError : Error
         Message = "StatusCode: " + statusCode.ToString();
     }
 
+    internal void SetStatusCode(HttpStatusCode statusCode, string? errorMessage = null, string? errorCode = null, string? errorTitle = null, string? errorDetail = null, string? errorInstance = null, string? errorType = null, IDictionary<string, object?>? errorExtensions = null)
+    {
+        var problemDetails = new ProblemDetails()
+        {
+            Title = errorTitle,
+            Detail = errorDetail,
+            Instance = errorInstance,
+            Type = errorType,
+            Status = (int)statusCode
+        };
+        if (errorExtensions != null)
+        {
+            problemDetails.Extensions.Clear();
+            foreach (var extension in errorExtensions)
+            {
+                problemDetails.Extensions.Add(extension.Key, extension.Value);
+            }
+        }
+        Code = string.IsNullOrEmpty(errorCode) ? statusCode.ToString().ToSnakeCase().ToUpper() : errorCode;
+        Message = string.IsNullOrEmpty(errorMessage) ? "StatusCode: " + statusCode.ToString() : errorMessage;
+        Detail = problemDetails;
+    }
+
     /// <inheritdoc/>
     public override object Clone()
     {

--- a/RestfulHelpers/Common/HttpResultExtension.cs
+++ b/RestfulHelpers/Common/HttpResultExtension.cs
@@ -85,25 +85,7 @@ public static class HttpResultExtension
         if (!string.IsNullOrEmpty(errorMessage) || !string.IsNullOrEmpty(errorCode) || !string.IsNullOrEmpty(errorTitle) || !string.IsNullOrEmpty(errorDetail) || !string.IsNullOrEmpty(errorInstance) || !string.IsNullOrEmpty(errorType) || errorExtensions != null)
         {
             HttpError httpError = new();
-            var problemDetails = new ProblemDetails()
-            {
-                Status = (int)statusCode,
-                Title = errorTitle,
-                Detail = errorDetail,
-                Instance = errorInstance,
-                Type = errorType
-            };
-            if (errorExtensions != null)
-            {
-                problemDetails.Extensions.Clear();
-                foreach (var extension in errorExtensions)
-                {
-                    problemDetails.Extensions.Add(extension.Key, extension.Value);
-                }
-            }
-            httpError.Code = errorCode;
-            httpError.Message = errorMessage;
-            httpError.Detail = problemDetails;
+            httpError.SetStatusCode(statusCode, errorMessage, errorCode, errorTitle, errorDetail, errorInstance, errorType, errorExtensions);
             httpResult.Append(new HttpResultAppend() { Errors = [httpError], StatusCode = statusCode, ShouldAppendErrors = true, ShouldAppendStatusCode = true });
         }
         else

--- a/RestfulHelpers/Common/RestfulHelpersJsonSerializerContext.cs
+++ b/RestfulHelpers/Common/RestfulHelpersJsonSerializerContext.cs
@@ -11,7 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace RestfulHelpers.Common;
 
 #if NET7_0_OR_GREATER
-internal class PatchForProblemDetails : global::Microsoft.AspNetCore.Mvc.ProblemDetails { }
+internal class PatchForProblemDetails : ProblemDetails { }
 
 [JsonSerializable(typeof(Result))]
 [JsonSerializable(typeof(Error))]


### PR DESCRIPTION
#### PR Classification
New feature to enhance error handling in the HTTP error management system.

#### PR Summary
This pull request introduces a new method for setting HTTP error details and refactors existing error handling logic for improved maintainability. 
- `HttpError.cs`: Added an internal method `SetStatusCode` to encapsulate the logic for initializing `ProblemDetails` and setting error properties.
- `HttpResultExtension.cs`: Replaced manual `ProblemDetails` creation with a call to `SetStatusCode` for cleaner error handling.
- `RestfulHelpersJsonSerializerContext.cs`: Modified the `PatchForProblemDetails` class to remove the `global::` prefix for simplification.
