### PR TITLE
Prevent duplicate header values in HttpResultCommon

### DIFF
--- a/RestfulHelpers/Common/HttpResult.cs
+++ b/RestfulHelpers/Common/HttpResult.cs
@@ -68,7 +68,13 @@ internal static class HttpResultCommon
                         if (httpResult.InternalResponseHeaders.TryGetValue(headerName, out string[]? value))
                         {
                             var existingValues = value.ToList();
-                            existingValues.AddRange(headerValues);
+                            foreach (var headerValue in headerValues)
+                            {
+                                if (!existingValues.Contains(headerValue))
+                                {
+                                    existingValues.Add(headerValue);
+                                }
+                            }
                             httpResult.InternalResponseHeaders[headerName] = [.. existingValues];
                         }
                         else


### PR DESCRIPTION
#### PR Classification
Code cleanup to prevent duplicate header values in the response.

#### PR Summary
The implementation for adding header values to the `existingValues` list was modified to avoid duplicates by checking for existing values before adding new ones. 
- `HttpResult.cs`: Changed the method of adding header values to use a loop that checks for duplicates instead of using `AddRange`.
